### PR TITLE
Fix #3: Document ARC_RELAY_SENTRY_DSN env var in README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ TOML config file with environment variable overrides:
 | `ARC_RELAY_DB_PATH` | `database.path` | `arc-relay.db` |
 | `ARC_RELAY_BASE_URL` | `server.base_url` | `http://localhost:PORT` |
 | `ARC_RELAY_PORT` | `server.port` | `8080` |
-| `ARC_RELAY_SENTRY_DSN` | – | (disabled) Sentry DSN for error reporting (optional; leave unset to disable Sentry) |
+| `ARC_RELAY_SENTRY_DSN` | `sentry_dsn` | (disabled) |
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ TOML config file with environment variable overrides:
 | `ARC_RELAY_DB_PATH` | `database.path` | `arc-relay.db` |
 | `ARC_RELAY_BASE_URL` | `server.base_url` | `http://localhost:PORT` |
 | `ARC_RELAY_PORT` | `server.port` | `8080` |
+| `ARC_RELAY_SENTRY_DSN` | – | (disabled) Sentry DSN for error reporting (optional; leave unset to disable Sentry) |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Arc Relay reads a TOML config file with environment variable overrides. See [`co
 | `ARC_RELAY_BASE_URL` | Public URL for OAuth callbacks |
 | `ARC_RELAY_LLM_API_KEY` | Anthropic API key for tool context optimization (optional) |
 | `ARC_RELAY_LLM_MODEL` | LLM model for optimization (default: `claude-haiku-4-5-20251001`) |
+| `ARC_RELAY_SENTRY_DSN` | Sentry DSN for error reporting (optional; leave unset to disable Sentry) |
 
 ## User Onboarding
 


### PR DESCRIPTION
## Description

Document the ARC_RELAY_SENTRY_DSN environment variable in both README.md and AGENTS.md, noting it is optional and that leaving it unset disables Sentry.

## Test Plan

Verified the change manually. Let me know if you'd like any additional tests or adjustments.

## Breaking Changes

- `README.md`
- `AGENTS.md`

## Related Issues

Fixes #3