### PR TITLE
Fix dead /connect links on dashboard

### DIFF
--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -69,7 +69,7 @@
     <ol style="text-align:left; max-width:480px; margin:1rem auto;">
       <li><a href="/servers/new">Add your first MCP server</a> (Docker, HTTP, or remote)</li>
       <li><a href="/users">Invite team members</a> so they can connect their AI tools</li>
-      <li><a href="/connect">Connect a client</a> (Claude Desktop, Cursor, VS Code, or Codex CLI)</li>
+      <li><a href="/connect/desktop">Connect a client</a> (Claude Desktop, Cursor, VS Code, or Codex CLI)</li>
     </ol>
     <a href="/servers/new" class="btn btn-primary">Add Your First Server</a>
     {{else}}
@@ -85,7 +85,7 @@
     <strong>Connect your AI tools</strong>
     <span style="color:var(--text-muted);font-size:0.85rem;"> - Claude Desktop, Cursor, VS Code, Codex CLI, or Claude Code</span>
   </div>
-  <a href="/connect" class="btn btn-primary btn-sm">Connect Clients</a>
+  <a href="/connect/desktop" class="btn btn-primary btn-sm">Connect Clients</a>
 </div>
 {{end}}
 


### PR DESCRIPTION
## Summary
- Dashboard had two links pointing to `/connect`, but only `/connect/desktop` is registered (`internal/web/handlers.go:307`).
- Updated the empty-state list item and the "Connect Clients" button to use `/connect/desktop`.

## Test plan
- [ ] Load the dashboard as an admin with no servers - click "Connect a client" in the Get Started list, confirm it loads the desktop connect page.
- [ ] Load the dashboard with at least one server - click the "Connect Clients" button, confirm it loads the desktop connect page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)