### PR TITLE
Guard nil endpoints and surface swallowed iteration/IO errors

### DIFF
--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -317,7 +317,12 @@ func tryInviteToken(baseURL, token, flagUsername, flagPassword string) string {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf(" failed\n")
+		fmt.Fprintf(os.Stderr, "Error reading response: %v\n", err)
+		return ""
+	}
 	var result struct {
 		APIKey string `json:"api_key"`
 		Error  string `json:"error"`
@@ -1209,7 +1214,10 @@ func tryDeviceAuth(baseURL string) string {
 		Interval        int    `json:"interval"`
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
 	if err := json.Unmarshal(body, &deviceResp); err != nil || deviceResp.DeviceCode == "" {
 		return ""
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -436,6 +436,10 @@ func (m *Manager) enumerateAsync(serverID, serverName string) {
 			slog.Warn("background enumeration failed", "server", serverName, "err", err)
 			return
 		}
+		if endpoints == nil {
+			slog.Warn("background enumeration returned no endpoints", "server", serverName)
+			return
+		}
 
 		toolCount := len(endpoints.Tools)
 		resourceCount := len(endpoints.Resources)

--- a/internal/store/access.go
+++ b/internal/store/access.go
@@ -57,6 +57,9 @@ func (s *AccessStore) GetAllTiers(serverID string) ([]EndpointTier, error) {
 		}
 		tiers = append(tiers, t)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating access tiers: %w", err)
+	}
 	return tiers, nil
 }
 

--- a/internal/store/profiles.go
+++ b/internal/store/profiles.go
@@ -93,6 +93,9 @@ func (s *ProfileStore) List() ([]*AgentProfile, error) {
 		}
 		profiles = append(profiles, p)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating profiles: %w", err)
+	}
 	return profiles, nil
 }
 
@@ -130,6 +133,9 @@ func (s *ProfileStore) GetPermissions(profileID string) ([]ProfilePermission, er
 		}
 		perms = append(perms, p)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating permissions: %w", err)
+	}
 	return perms, nil
 }
 
@@ -152,6 +158,9 @@ func (s *ProfileStore) GetPermissionsForServer(profileID, serverID string) ([]Pr
 			return nil, fmt.Errorf("scanning permission: %w", err)
 		}
 		perms = append(perms, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating server permissions: %w", err)
 	}
 	return perms, nil
 }


### PR DESCRIPTION
## Summary
- `ProfileStore.List`, `GetPermissions`, `GetPermissionsForServer` and `AccessStore.GetAllTiers` now return `rows.Err()` after iteration so driver-level iteration failures are no longer silently swallowed.
- `enumerateAsync` guards against a nil `*mcp.ServerEndpoints` (since `EnumerateServer` can return `(nil, err)`) before dereferencing `.Tools` / `.Resources` / `.Prompts` / `.ServerInfo`.
- Two `io.ReadAll` calls in `cmd/arc-sync/main.go` (`tryInviteToken`, `tryDeviceAuth`) now check the read error instead of discarding it with `_`, so network read failures are distinguishable from JSON parse failures.

## Test plan
- [x] `/usr/local/go/bin/go build ./...`
- [x] `/usr/local/go/bin/go vet ./...`
- [x] `/usr/local/go/bin/go test ./internal/store/... ./internal/proxy/... ./cmd/arc-sync/...`
- [x] Pre-push hooks (gofmt, staticcheck, golangci-lint, full test suite) all pass