### PR TITLE
fix(oauth): persist discovered auth_url and token_url after re-registration

### DIFF
--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -123,12 +123,19 @@ func (m *Manager) ReRegisterIfNeeded(ctx context.Context, serverID string, srv *
 		slog.Info("OAuth redirect URI changed, re-registering", "server_id", serverID, "old_uri", auth.RegisteredRedirectURI, "new_uri", callbackURL)
 	}
 
-	// Try using stored registration endpoint first, fall back to re-discovery
+	// Run discovery if we're missing any of the endpoints required to start an
+	// OAuth flow. RegistrationEndpoint is needed to (re-)register; AuthURL and
+	// TokenURL are needed by StartAuthFlow / exchangeCode. A previous version
+	// of this function persisted only RegistrationEndpoint, so brand-new servers
+	// could end up with empty AuthURL/TokenURL even after a successful discovery
+	// pass — StartAuthFlow then built `"" + "?" + params` which the browser
+	// resolved relative to /oauth/start/, returning 404.
 	regEndpoint := auth.RegistrationEndpoint
-	if regEndpoint == "" {
+	needsDiscovery := regEndpoint == "" || cfg.Auth.AuthURL == "" || cfg.Auth.TokenURL == ""
+	var disc *OAuthDiscovery
+	if needsDiscovery {
 		// Try discovering from the server URL first, then from the auth URL origin
 		// (the OAuth provider may be on a different host than the MCP server)
-		var disc *OAuthDiscovery
 		for _, tryURL := range []string{cfg.URL, auth.AuthURL} {
 			if tryURL == "" {
 				continue
@@ -141,19 +148,21 @@ func (m *Manager) ReRegisterIfNeeded(ctx context.Context, serverID string, srv *
 			}
 			if d != nil && d.RegistrationEndpoint != "" {
 				disc = d
-				slog.Debug("OAuth discovery found registration endpoint", "endpoint", d.RegistrationEndpoint)
+				slog.Debug("OAuth discovery found endpoints", "registration", d.RegistrationEndpoint, "auth", d.AuthURL, "token", d.TokenURL)
 				break
 			}
 		}
-		if disc == nil || disc.RegistrationEndpoint == "" {
-			if auth.RegisteredRedirectURI == "" {
-				// Never tracked — can't re-register, proceed with existing credentials
-				slog.Info("no registration endpoint found, proceeding with existing credentials", "server_id", serverID)
-				return false, nil
+		if regEndpoint == "" {
+			if disc == nil || disc.RegistrationEndpoint == "" {
+				if auth.RegisteredRedirectURI == "" {
+					// Never tracked — can't re-register, proceed with existing credentials
+					slog.Info("no registration endpoint found, proceeding with existing credentials", "server_id", serverID)
+					return false, nil
+				}
+				return false, fmt.Errorf("redirect URI changed but cannot re-register: no registration endpoint found (update client credentials manually)")
 			}
-			return false, fmt.Errorf("redirect URI changed but cannot re-register: no registration endpoint found (update client credentials manually)")
+			regEndpoint = disc.RegistrationEndpoint
 		}
-		regEndpoint = disc.RegistrationEndpoint
 	}
 
 	reg, err := RegisterClient(ctx, regEndpoint, callbackURL)
@@ -166,6 +175,16 @@ func (m *Manager) ReRegisterIfNeeded(ctx context.Context, serverID string, srv *
 	cfg.Auth.ClientSecret = reg.ClientSecret
 	cfg.Auth.RegisteredRedirectURI = callbackURL
 	cfg.Auth.RegistrationEndpoint = regEndpoint
+	// Persist any newly-discovered authorization / token endpoints so subsequent
+	// StartAuthFlow / exchangeCode calls have the URLs they need.
+	if disc != nil {
+		if disc.AuthURL != "" {
+			cfg.Auth.AuthURL = disc.AuthURL
+		}
+		if disc.TokenURL != "" {
+			cfg.Auth.TokenURL = disc.TokenURL
+		}
+	}
 	// Clear old tokens since they belong to the old client
 	cfg.Auth.AccessToken = ""
 	cfg.Auth.RefreshToken = ""


### PR DESCRIPTION
## Description

`ReRegisterIfNeeded` runs OAuth discovery and (re-)registers the client, but it only persists `RegistrationEndpoint`, `ClientID`, `ClientSecret`, and `RegisteredRedirectURI`. `disc.AuthURL` and `disc.TokenURL` are dropped on the floor.

For a freshly-created remote OAuth server (e.g. via the web UI or `POST /api/servers` with `auth.type: "oauth"`), all four fields start empty. The first Authorize click triggers discovery → DCR → success, but `cfg.Auth.AuthURL` stays `""`. `StartAuthFlow` then builds:

```go
authURL := auth.AuthURL + "?" + params.Encode()
```

…which becomes `?response_type=...`. The browser resolves this relative URL against the current path `/oauth/start/<id>`, navigates to `/oauth/start/`, and `handleOAuthStart` 404s because the trailing-slash request has no server id.

## Reproduction

1. Add a remote OAuth server pointing at any MCP host that supports OIDC discovery + DCR (we hit it with Outline's hosted MCP at `https://<workspace>.getoutline.com/mcp`).
2. Click Authorize. Expected: 302 to provider's `/oauth/authorize`. Actual: 302 → relative `?...` Location → browser navigates to `/oauth/start/` → 404.
3. Inspect the server's stored config via `/api/servers`: `auth.auth_url` and `auth.token_url` are both null/empty even though re-registration "succeeded".

## Fix

Two changes in `internal/oauth/oauth.go` `ReRegisterIfNeeded`:

1. **Re-trigger discovery when `AuthURL` or `TokenURL` is missing**, not only when `RegistrationEndpoint` is empty. This lets a server in a half-populated state self-heal on the next Authorize attempt.
2. **After `RegisterClient` succeeds, copy `disc.AuthURL` / `disc.TokenURL` into `cfg.Auth`** so the persisted config has everything `StartAuthFlow` and `exchangeCode` need.

## Test Plan

- [x] Reproduced 404 on a fresh outline server before the fix.
- [x] After applying the patch live (via `PUT /api/servers/<id>` populating the missing URLs), the OAuth flow completes and tokens are captured.
- [ ] Existing servers that already have `RegistrationEndpoint`, `AuthURL`, and `TokenURL` populated should be unaffected — `needsDiscovery` is false, original behavior preserved.

No new tests included — `internal/oauth/` has no existing test scaffolding to extend; happy to add one if reviewers prefer.

## Breaking Changes

None. Behavior change only triggers when previously-broken state was already present.