### PR TITLE
fix(docker): bump builder image to golang:1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev sqlite-dev
 


### PR DESCRIPTION
## What

Bump the Docker builder base image from `golang:1.24-alpine` to `golang:1.25-alpine`.

## Why

The `v0.1.2` release Docker build failed at `RUN go mod download`:

```
#20 [builder 5/7] RUN go mod download
#20 0.041 go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
#20 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

The recent dependency bump raised the `go` directive in `go.mod` to `go 1.25.0`, but the Dockerfile builder stage was still pinned to `golang:1.24-alpine`. The official `golang` images set `GOTOOLCHAIN=local`, so the in-image toolchain (go 1.24.13) is never auto-upgraded and `go mod download` refuses to run against a module that requires `>= 1.25.0`.

CI (`ci.yml`) and the `release` job already use `setup-go` with `go-version: "1.25"`, which is why only the `docker` job broke. This change realigns the Docker builder with the rest of the toolchain.

## Verification

Built the builder stage locally against the bumped image - `go mod download` and `go build` both succeed under go 1.25:

```
docker build --target builder -t arc-relay-builder-verify .
```

## Notes

The `docker` job only runs on `v*` tag pushes, not on PRs, so this fix is not exercised by PR CI. After merge, cut a new patch tag (e.g. `v0.1.3`) to republish - the `v0.1.2` binaries/GitHub release already published successfully; only the container image is missing for that tag.
