### PR TITLE
fix(arc-relay): confine variable file paths (Oneleet SAST file-inclusion)

### DIFF
--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -389,7 +389,7 @@ func offerClaudeIntegration(scanner *bufio.Scanner) {
 	hasInstructions := false
 	hasSkill := false
 
-	if data, err := os.ReadFile(claudeMDPath); err == nil {
+	if data, err := os.ReadFile(claudeMDPath); err == nil { // #nosec G304 — homeDir + constant ".claude/CLAUDE.md"; integration-doc read, no credentials.
 		hasInstructions = strings.Contains(string(data), claudeInstructionsMarker)
 	}
 	if _, err := os.Stat(skillPath); err == nil {
@@ -434,7 +434,7 @@ func offerClaudeIntegration(scanner *bufio.Scanner) {
 		if err := os.MkdirAll(claudeDir, 0700); err != nil {
 			fmt.Fprintf(os.Stderr, "   Warning: could not create %s: %v\n", claudeDir, err)
 		} else {
-			f, err := os.OpenFile(claudeMDPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(claudeMDPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G304 — homeDir + constant ".claude/CLAUDE.md"; appends integration doc, no credentials.
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "   Warning: could not write %s: %v\n", claudeMDPath, err)
 			} else {
@@ -615,7 +615,7 @@ func installProjectClaude(projectDir string) bool {
 		return false
 	}
 
-	f, err := os.OpenFile(claudePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G302 - project file, git will set perms
+	f, err := os.OpenFile(claudePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G302 G304 - projectDir + constant ".claude/CLAUDE.md"; appends integration doc, no credentials. git will set perms
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "   Warning: could not write %s: %v\n", claudePath, err)
 		return false
@@ -641,7 +641,7 @@ func installProjectCodex(projectDir string) bool {
 	}
 
 	snippet := projectCodexSnippet
-	if data, err := os.ReadFile(agentsPath); err == nil && len(data) > 0 {
+	if data, err := os.ReadFile(agentsPath); err == nil && len(data) > 0 { // #nosec G304 — projectDir + constant "AGENTS.md"; integration-doc read, no credentials.
 		snippet = "\n" + snippet
 	}
 
@@ -671,7 +671,7 @@ func installSkillFromEmbed(skillDir, skillPath string) error {
 		return fmt.Errorf("creating skill directory: %w", err)
 	}
 
-	if err := os.WriteFile(skillPath, embeddedSkillMD, 0600); err != nil {
+	if err := os.WriteFile(skillPath, embeddedSkillMD, 0600); err != nil { // #nosec G304 — homeDir + constant "skills/arc-sync/SKILL.md"; writes embedded skill doc, no credentials.
 		return fmt.Errorf("writing skill: %w", err)
 	}
 
@@ -679,7 +679,9 @@ func installSkillFromEmbed(skillDir, skillPath string) error {
 }
 
 func hasMarker(path, marker string) bool {
-	data, err := os.ReadFile(path)
+	// path is always built by callers as homeDir/projectDir + a constant
+	// integration-doc name (CLAUDE.md / AGENTS.md); read-only marker check.
+	data, err := os.ReadFile(path) // #nosec G304 — caller-constructed homeDir/projectDir + constant doc name; read-only marker check.
 	if err != nil {
 		return false
 	}
@@ -691,7 +693,7 @@ func appendSnippetIfMissing(path, marker, snippet string) error {
 		return nil
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G304 — caller-constructed homeDir/projectDir + constant doc name; appends integration doc, no credentials.
 	if err != nil {
 		return err
 	}
@@ -1132,7 +1134,7 @@ func runStatus() {
 
 		// Global CLAUDE.md
 		claudeMDPath := filepath.Join(homeDir, ".claude", "CLAUDE.md")
-		if data, err := os.ReadFile(claudeMDPath); err == nil && strings.Contains(string(data), claudeInstructionsMarker) {
+		if data, err := os.ReadFile(claudeMDPath); err == nil && strings.Contains(string(data), claudeInstructionsMarker) { // #nosec G304 — homeDir + constant ".claude/CLAUDE.md"; status read of integration doc.
 			fmt.Println("  ✓  Global CLAUDE.md:  installed")
 		} else {
 			fmt.Println("  ✗  Global CLAUDE.md:  not found  (run: arc-sync setup-claude)")

--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -1134,7 +1134,8 @@ func runStatus() {
 
 		// Global CLAUDE.md
 		claudeMDPath := filepath.Join(homeDir, ".claude", "CLAUDE.md")
-		if data, err := os.ReadFile(claudeMDPath); err == nil && strings.Contains(string(data), claudeInstructionsMarker) { // #nosec G304 — homeDir + constant ".claude/CLAUDE.md"; status read of integration doc.
+		claudeData, claudeErr := os.ReadFile(claudeMDPath) // #nosec G304 - homeDir + constant ".claude/CLAUDE.md"; status read of integration doc.
+		if claudeErr == nil && strings.Contains(string(claudeData), claudeInstructionsMarker) {
 			fmt.Println("  ✓  Global CLAUDE.md:  installed")
 		} else {
 			fmt.Println("  ✗  Global CLAUDE.md:  not found  (run: arc-sync setup-claude)")

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/comma-compliance/arc-relay/internal/safefile"
 )
 
 const (
@@ -44,7 +46,8 @@ func ConfigPath(configDir string) string {
 // if the config file doesn't exist or is invalid.
 func LoadConfig(configDir string) (*Config, error) {
 	path := ConfigPath(configDir)
-	data, err := os.ReadFile(path)
+	// Confine the read to configDir; the file holds the relay API key.
+	data, err := safefile.ReadFile(configDir, configFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("no configuration found — run 'arc-sync init' to get started, or 'arc-sync --help' for usage")
@@ -81,7 +84,7 @@ func SaveConfig(configDir string, cfg *Config) error {
 	data = append(data, '\n')
 
 	path := ConfigPath(configDir)
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := safefile.WriteFile(configDir, configFileName, data, 0600); err != nil {
 		return fmt.Errorf("writing config %s: %w", path, err)
 	}
 

--- a/internal/cli/config/state.go
+++ b/internal/cli/config/state.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/comma-compliance/arc-relay/internal/safefile"
 )
 
 const stateFileName = "state.json"
@@ -30,8 +32,7 @@ func StatePath(configDir string) string {
 // LoadState loads state from the given directory. Returns an empty state if the
 // file doesn't exist.
 func LoadState(configDir string) (*State, error) {
-	path := StatePath(configDir)
-	data, err := os.ReadFile(path)
+	data, err := safefile.ReadFile(configDir, stateFileName)
 	if err != nil {
 		// Return empty state on any read error — callers use
 		// state, _ := LoadState() and would panic on nil.
@@ -65,7 +66,7 @@ func SaveState(configDir string, state *State) error {
 	data = append(data, '\n')
 
 	path := StatePath(configDir)
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := safefile.WriteFile(configDir, stateFileName, data, 0600); err != nil {
 		return fmt.Errorf("writing state %s: %w", path, err)
 	}
 

--- a/internal/cli/project/claude.go
+++ b/internal/cli/project/claude.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/comma-compliance/arc-relay/internal/safefile"
 )
 
 const claudeConfigFile = ".mcp.json"
@@ -44,7 +46,9 @@ type mcpServerEntry struct {
 
 func (c *ClaudeCodeTarget) Read(projectDir, relayBaseURL string) ([]ManagedServer, error) {
 	path := filepath.Join(projectDir, claudeConfigFile)
-	data, err := os.ReadFile(path)
+	// Confine the read to projectDir so a symlinked .mcp.json in a hostile
+	// project tree cannot redirect us outside it.
+	data, err := safefile.ReadFile(projectDir, claudeConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -81,7 +85,7 @@ func (c *ClaudeCodeTarget) Write(projectDir, relayBaseURL, apiKey string, server
 
 	// Load existing file or start fresh
 	var raw map[string]json.RawMessage
-	data, err := os.ReadFile(path)
+	data, err := safefile.ReadFile(projectDir, claudeConfigFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("reading %s: %w", path, err)
@@ -132,7 +136,7 @@ func (c *ClaudeCodeTarget) Write(projectDir, relayBaseURL, apiKey string, server
 	}
 	output = append(output, '\n')
 
-	if err := os.WriteFile(path, output, 0600); err != nil {
+	if err := safefile.WriteFile(projectDir, claudeConfigFile, output, 0600); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 
@@ -142,7 +146,7 @@ func (c *ClaudeCodeTarget) Write(projectDir, relayBaseURL, apiKey string, server
 func (c *ClaudeCodeTarget) Remove(projectDir string, names []string) ([]string, error) {
 	path := filepath.Join(projectDir, claudeConfigFile)
 
-	data, err := os.ReadFile(path)
+	data, err := safefile.ReadFile(projectDir, claudeConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -194,7 +198,7 @@ func (c *ClaudeCodeTarget) Remove(projectDir string, names []string) ([]string, 
 	}
 	output = append(output, '\n')
 
-	if err := os.WriteFile(path, output, 0600); err != nil {
+	if err := safefile.WriteFile(projectDir, claudeConfigFile, output, 0600); err != nil {
 		return nil, fmt.Errorf("writing %s: %w", path, err)
 	}
 

--- a/internal/cli/project/codex.go
+++ b/internal/cli/project/codex.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/comma-compliance/arc-relay/internal/safefile"
 )
 
 const codexConfigFile = ".codex/config.toml"
@@ -30,8 +32,7 @@ func (c *CodexTarget) Detect(projectDir string) bool {
 }
 
 func (c *CodexTarget) Read(projectDir, relayBaseURL string) ([]ManagedServer, error) {
-	path := filepath.Join(projectDir, codexConfigFile)
-	raw, err := loadCodexConfig(path)
+	raw, err := loadCodexConfig(projectDir)
 	if err != nil {
 		return nil, err
 	}
@@ -66,9 +67,7 @@ func (c *CodexTarget) Read(projectDir, relayBaseURL string) ([]ManagedServer, er
 }
 
 func (c *CodexTarget) Write(projectDir, relayBaseURL, apiKey string, servers []ManagedServer) error {
-	path := filepath.Join(projectDir, codexConfigFile)
-
-	raw, err := loadCodexConfig(path)
+	raw, err := loadCodexConfig(projectDir)
 	if err != nil {
 		return err
 	}
@@ -91,13 +90,11 @@ func (c *CodexTarget) Write(projectDir, relayBaseURL, apiKey string, servers []M
 	}
 
 	raw["mcp_servers"] = mcpServers
-	return writeCodexConfig(path, raw)
+	return writeCodexConfig(projectDir, raw)
 }
 
 func (c *CodexTarget) Remove(projectDir string, names []string) ([]string, error) {
-	path := filepath.Join(projectDir, codexConfigFile)
-
-	raw, err := loadCodexConfig(path)
+	raw, err := loadCodexConfig(projectDir)
 	if err != nil {
 		return nil, err
 	}
@@ -131,15 +128,18 @@ func (c *CodexTarget) Remove(projectDir string, names []string) ([]string, error
 	}
 
 	raw["mcp_servers"] = mcpServers
-	if err := writeCodexConfig(path, raw); err != nil {
+	if err := writeCodexConfig(projectDir, raw); err != nil {
 		return nil, err
 	}
 
 	return removed, nil
 }
 
-func loadCodexConfig(path string) (map[string]any, error) {
-	data, err := os.ReadFile(path)
+// loadCodexConfig reads projectDir/.codex/config.toml, confined to projectDir so
+// a symlinked config in a hostile project tree cannot redirect the read.
+func loadCodexConfig(projectDir string) (map[string]any, error) {
+	path := filepath.Join(projectDir, codexConfigFile)
+	data, err := safefile.ReadFile(projectDir, codexConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -159,7 +159,11 @@ func loadCodexConfig(path string) (map[string]any, error) {
 	return raw, nil
 }
 
-func writeCodexConfig(path string, raw map[string]any) error {
+// writeCodexConfig writes projectDir/.codex/config.toml, confined to projectDir.
+// The .codex parent directory is created first so the confined write has an
+// existing, in-base parent to resolve against.
+func writeCodexConfig(projectDir string, raw map[string]any) error {
+	path := filepath.Join(projectDir, codexConfigFile)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
 	}
@@ -169,7 +173,7 @@ func writeCodexConfig(path string, raw map[string]any) error {
 		return fmt.Errorf("encoding %s: %w", path, err)
 	}
 
-	if err := os.WriteFile(path, buf.Bytes(), 0600); err != nil {
+	if err := safefile.WriteFile(projectDir, codexConfigFile, buf.Bytes(), 0600); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 

--- a/internal/cli/safety/gitignore.go
+++ b/internal/cli/safety/gitignore.go
@@ -85,7 +85,10 @@ func CheckGitignore(projectDir, filename string) []Warning {
 // in the .gitignore file. This is a basic check — it doesn't handle negation,
 // directory-only patterns, or nested .gitignore files.
 func isInGitignore(gitignorePath, filename string) bool {
-	f, err := os.Open(gitignorePath)
+	// gitignorePath is filepath.Join(projectDir, ".gitignore") built by the
+	// caller from a constant filename; this is a read-only scan for a gitignore
+	// entry (no credentials read or written), so it is confined by construction.
+	f, err := os.Open(gitignorePath) // #nosec G304 — projectDir + constant ".gitignore"; read-only gitignore scan.
 	if err != nil {
 		return false
 	}

--- a/internal/cli/testutil/golden.go
+++ b/internal/cli/testutil/golden.go
@@ -27,7 +27,7 @@ func GoldenFile(t *testing.T, name string, got []byte) {
 		return
 	}
 
-	expected, err := os.ReadFile(golden)
+	expected, err := os.ReadFile(golden) // #nosec G304 — test-only helper; golden is "testdata/golden/" + a test-supplied constant name.
 	if err != nil {
 		t.Fatalf("failed to read golden file %s (run with -update to create): %v", golden, err)
 	}

--- a/internal/safefile/safefile.go
+++ b/internal/safefile/safefile.go
@@ -1,0 +1,186 @@
+// Package safefile provides base-directory-confined file access.
+//
+// arc-sync reads and writes credential-bearing config files (.mcp.json,
+// .codex/config.toml, config.json, state.json) inside whatever project or
+// user-config directory the CLI is pointed at. Those files can contain
+// "Authorization: Bearer <token>" headers. If an attacker can plant a symlink
+// at one of those paths — for example, a hostile project repository a user
+// clones and then runs arc-sync inside — a naive os.WriteFile would follow the
+// link and write the token to an arbitrary location outside the project.
+//
+// The helpers here confine all access to an explicit base directory: the
+// relative sub-path may not be absolute, may not escape the base with "..",
+// and neither the resolved parent directory nor the final component may be a
+// symlink that points outside the base. This is defense-in-depth for a CLI
+// that already runs with the user's own privileges; the goal is to stop a
+// malicious *directory tree* from redirecting a token write, not to defend
+// against an attacker who already controls the user's account.
+//
+// Confinement is best-effort against a concurrent local attacker (a
+// check-then-open sequence is inherently TOCTOU-prone), but it deterministically
+// rejects the static symlink-redirect case, which is the realistic threat here.
+package safefile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolve validates that rel stays within base and returns the cleaned absolute
+// path of the target. It rejects absolute rel paths and any ".." traversal that
+// would escape base. It does not touch the filesystem.
+func resolve(base, rel string) (string, error) {
+	if rel == "" {
+		return "", fmt.Errorf("safefile: empty relative path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("safefile: %q is absolute, must be relative to base", rel)
+	}
+	// On Windows a path like `C:foo` is not reported absolute by IsAbs but still
+	// carries a volume; reject any volume-qualified rel so it can never anchor
+	// outside base. (Current callers pass constants, but keep the guard.)
+	if filepath.VolumeName(rel) != "" {
+		return "", fmt.Errorf("safefile: %q is volume-qualified, must be relative to base", rel)
+	}
+
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", fmt.Errorf("safefile: resolving base %q: %w", base, err)
+	}
+	absBase = filepath.Clean(absBase)
+
+	target := filepath.Clean(filepath.Join(absBase, rel))
+
+	// Re-derive the relationship from the cleaned paths: rel must not climb out
+	// of base. filepath.Rel handles "." and nested paths correctly across
+	// platforms (including Windows volume/case semantics for same-volume paths).
+	within, err := filepath.Rel(absBase, target)
+	if err != nil {
+		return "", fmt.Errorf("safefile: %q escapes base %q", rel, base)
+	}
+	if within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("safefile: %q escapes base %q", rel, base)
+	}
+
+	return target, nil
+}
+
+// checkNoSymlinkEscape verifies that the already-existing portion of target does
+// not leave base via a symlink. It evaluates symlinks on the deepest existing
+// ancestor of target (the file itself if it exists, otherwise its parent
+// directory, walking up as needed) and confirms the real path is still inside
+// the real base. A write target that does not yet exist is allowed as long as
+// its existing parent resolves inside base and the final component, if present,
+// is not itself a symlink.
+func checkNoSymlinkEscape(absBase, target string) error {
+	realBase, err := filepath.EvalSymlinks(absBase)
+	if err != nil {
+		// Base must exist and resolve for confinement to mean anything; callers
+		// create it (MkdirAll) before writing.
+		return fmt.Errorf("safefile: resolving base %q: %w", absBase, err)
+	}
+	realBase = filepath.Clean(realBase)
+
+	// If the final component already exists, reject it being a symlink outright —
+	// we never want to follow a link at the leaf for a confined write/read.
+	if info, lerr := os.Lstat(target); lerr == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("safefile: refusing to follow symlink at %q", target)
+		}
+	}
+
+	// Find the deepest ancestor that exists and resolve it. EvalSymlinks fails on
+	// a path whose leaf does not exist yet, which is the normal case for a fresh
+	// write, so we walk up to the nearest existing directory.
+	probe := target
+	for {
+		resolved, err := filepath.EvalSymlinks(probe)
+		if err == nil {
+			resolved = filepath.Clean(resolved)
+			if resolved != realBase &&
+				!strings.HasPrefix(resolved, realBase+string(filepath.Separator)) {
+				return fmt.Errorf("safefile: %q resolves outside base %q (symlink escape)", target, absBase)
+			}
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("safefile: resolving %q: %w", probe, err)
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			// Walked to the filesystem root without finding an existing ancestor.
+			return fmt.Errorf("safefile: no existing ancestor for %q under base %q", target, absBase)
+		}
+		probe = parent
+	}
+}
+
+// confinedPath validates rel against base and verifies no symlink escape, then
+// returns the concrete path to operate on.
+//
+// If base itself does not exist, confinement is moot (there is nothing to
+// escape into) and the second return value is false, signaling callers to fall
+// back to a raw os call against target so the canonical *PathError /
+// os.IsNotExist behavior is preserved for not-yet-initialized directories.
+func confinedPath(base, rel string) (target string, confined bool, err error) {
+	target, err = resolve(base, rel)
+	if err != nil {
+		return "", false, err
+	}
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", false, fmt.Errorf("safefile: resolving base %q: %w", base, err)
+	}
+	absBase = filepath.Clean(absBase)
+	if _, statErr := os.Lstat(absBase); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return target, false, nil
+		}
+		return "", false, fmt.Errorf("safefile: resolving base %q: %w", absBase, statErr)
+	}
+	if err := checkNoSymlinkEscape(absBase, target); err != nil {
+		return "", false, err
+	}
+	return target, true, nil
+}
+
+// ReadFile reads base/rel, confined to base. rel must be a relative path that
+// does not escape base, and the resolved path must not cross a symlink out of
+// base.
+func ReadFile(base, rel string) ([]byte, error) {
+	target, _, err := confinedPath(base, rel)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(target) // #nosec G304 — target is confined to base by confinedPath above (or base is absent, yielding a canonical not-exist error).
+}
+
+// WriteFile writes data to base/rel with the given perm, confined to base. The
+// existing parent directory must already resolve inside base (callers create it
+// with MkdirAll first); the final component must not be a pre-existing symlink.
+func WriteFile(base, rel string, data []byte, perm os.FileMode) error {
+	target, _, err := confinedPath(base, rel)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(target, data, perm) // #nosec G304 — target is confined to base by confinedPath above.
+}
+
+// Open opens base/rel for reading, confined to base.
+func Open(base, rel string) (*os.File, error) {
+	target, _, err := confinedPath(base, rel)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(target) // #nosec G304 — target is confined to base by confinedPath above (or base is absent, yielding a canonical not-exist error).
+}
+
+// Path validates that base/rel is confined to base and returns the resolved
+// path without opening it. Use this for callers that need the path for an
+// os.OpenFile with custom flags (e.g. append) but still want confinement.
+func Path(base, rel string) (string, error) {
+	target, _, err := confinedPath(base, rel)
+	return target, err
+}

--- a/internal/safefile/safefile_test.go
+++ b/internal/safefile/safefile_test.go
@@ -1,0 +1,129 @@
+package safefile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestReadWriteRoundTrip(t *testing.T) {
+	base := t.TempDir()
+	if err := WriteFile(base, "config.json", []byte("hello"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := ReadFile(base, "config.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("round trip mismatch: got %q", got)
+	}
+}
+
+func TestWriteCreatesNestedUnderExistingParent(t *testing.T) {
+	base := t.TempDir()
+	// Parent must already exist for a confined write — mirror caller behavior.
+	if err := os.MkdirAll(filepath.Join(base, ".codex"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(base, ".codex/config.toml", []byte("x"), 0600); err != nil {
+		t.Fatalf("WriteFile nested: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, ".codex", "config.toml")); err != nil {
+		t.Fatalf("expected file written: %v", err)
+	}
+}
+
+func TestRejectsAbsoluteRel(t *testing.T) {
+	base := t.TempDir()
+	abs := filepath.Join(t.TempDir(), "outside.json")
+	if err := WriteFile(base, abs, []byte("x"), 0600); err == nil {
+		t.Fatal("expected WriteFile to reject absolute rel path")
+	}
+	if _, err := ReadFile(base, abs); err == nil {
+		t.Fatal("expected ReadFile to reject absolute rel path")
+	}
+}
+
+func TestRejectsTraversalEscape(t *testing.T) {
+	base := t.TempDir()
+	for _, rel := range []string{"../escape.json", "a/../../escape.json", ".."} {
+		if _, err := Path(base, rel); err == nil {
+			t.Fatalf("expected %q to be rejected as traversal", rel)
+		}
+	}
+}
+
+func TestAllowsInternalDotDot(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "a"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	// a/../config.json normalizes back to config.json — inside base, must be allowed.
+	p, err := Path(base, "a/../config.json")
+	if err != nil {
+		t.Fatalf("internal .. that stays in base should be allowed: %v", err)
+	}
+	if p != filepath.Join(base, "config.json") {
+		t.Fatalf("unexpected resolved path: %q", p)
+	}
+}
+
+func TestRejectsSymlinkLeafEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows CI")
+	}
+	base := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.json")
+	if err := os.WriteFile(outside, []byte("preexisting"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Plant a symlink inside base that points outside it.
+	link := filepath.Join(base, ".mcp.json")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// A confined write must refuse to follow the leaf symlink (which would
+	// clobber the outside file with a token-bearing config).
+	if err := WriteFile(base, ".mcp.json", []byte("token"), 0600); err == nil {
+		t.Fatal("expected WriteFile to refuse following a leaf symlink")
+	}
+	// The outside file must be untouched.
+	got, _ := os.ReadFile(outside)
+	if string(got) != "preexisting" {
+		t.Fatalf("outside file was modified through symlink: %q", got)
+	}
+	// A confined read must likewise refuse.
+	if _, err := ReadFile(base, ".mcp.json"); err == nil {
+		t.Fatal("expected ReadFile to refuse following a leaf symlink")
+	}
+}
+
+func TestRejectsSymlinkedParentEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows CI")
+	}
+	base := t.TempDir()
+	outsideDir := t.TempDir()
+	// base/.claude -> outsideDir, then write base/.claude/CLAUDE.md should be
+	// rejected because the parent resolves outside base.
+	if err := os.Symlink(outsideDir, filepath.Join(base, ".claude")); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(base, ".claude/CLAUDE.md", []byte("x"), 0600); err == nil {
+		t.Fatal("expected WriteFile to reject a symlinked parent escaping base")
+	}
+	if _, err := os.Stat(filepath.Join(outsideDir, "CLAUDE.md")); err == nil {
+		t.Fatal("file leaked outside base through symlinked parent")
+	}
+}
+
+func TestReadMissingFilePropagatesNotExist(t *testing.T) {
+	base := t.TempDir()
+	_, err := ReadFile(base, "config.json")
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist for missing file, got %v", err)
+	}
+}


### PR DESCRIPTION
> 🤖 This PR was generated by Claude Code.

## Summary

Hardens the Oneleet "file inclusion via variable" (gosec **G304** / CWE-22) SAST findings. The Go dependency-CVE work was already merged (#18); this is **hardening only** - no dependency changes.

**Triage outcome:** none of the file-inclusion findings reaches an attacker-controlled path. The server-side filesystem sinks that touch network input are already confined (download-name allowlist in the device-auth handler, `..`-rejection + no-symlink-deref in the Docker build-context tar walk, `MkdirTemp` + git-URL validation for repo builds). Every remaining hit is in the `arc-sync` **CLI**, where the path is a local base directory (`projectDir` / `configDir` / `homeDir`) joined with a **compile-time-constant filename**. Server names that come from the relay API (network input) are used only as JSON/TOML keys and for display - never to build a filesystem path.

Rather than blanket-suppress, this adds real defense-in-depth for the sensitive case. The CLI reads and writes **credential-bearing** config (`.mcp.json`, `.codex/config.toml`, `config.json`, `state.json` - these hold `Authorization: Bearer <token>`) inside whatever directory it is pointed at. A symlink planted in a hostile project tree a user `cd`s into could otherwise redirect a token write outside the project. The new helper closes that and clears the scanner at the same time.

### Fixed (routed through base-dir confinement) - 8 sites
New package **`internal/safefile`** provides `ReadFile` / `WriteFile` / `Open` / `Path` confined to an explicit base dir: rejects absolute and `..`-escaping sub-paths, and refuses to follow a symlink that escapes the base (both leaf-symlink and symlinked-parent are checked). The token-bearing CLI reads/writes now go through it:

| File | Sinks confined |
|------|----------------|
| `internal/cli/project/claude.go` | `.mcp.json` read (×3) + write (×2) |
| `internal/cli/project/codex.go` | `.codex/config.toml` read + write |
| `internal/cli/config/config.go` | `config.json` read + write |
| `internal/cli/config/state.go` | `state.json` read + write |

### Justified-suppressed (tight per-line `#nosec G304`) - non-credential, constant-path
These are not credential files and don't fit a base+rel split cleanly; each gets a specific inline justification:

| File:line | Path provenance | Why suppressed |
|-----------|-----------------|----------------|
| `cmd/arc-sync/main.go` (×8: 392, 437, 618, 644, 674, 682, 694, 1135) | `homeDir`/`projectDir` + constant `CLAUDE.md` / `AGENTS.md` / `SKILL.md` | integration-doc installers + status/marker reads, no credentials |
| `internal/cli/safety/gitignore.go:88` | `projectDir` + constant `.gitignore` | read-only gitignore scan |
| `internal/cli/testutil/golden.go:30` | `"testdata/golden/" + const name` | test-only golden helper |

`gosec` honors inline `#nosec`; the repo already uses this vehicle (its CI additionally excludes G304 globally, so these findings originate from Oneleet's separate default-config scan).

## Test plan
- `go build ./...` - clean
- `go test ./...` (CGO on, all packages) - **green**, including the existing `internal/cli/config`, `internal/cli/project`, and `internal/cli/sync` tests that exercise the rerouted read/write paths
- New `internal/safefile/safefile_test.go` - round-trip, absolute-rel rejection, `..`-traversal rejection, internal-`..`-allowed, **leaf-symlink-escape rejection**, **symlinked-parent-escape rejection**, not-exist propagation
- `gofmt -l` clean; `staticcheck ./...` clean
- **gosec G304 across the whole tree: 15 → 0**

## Out of scope
- govulncheck reports stdlib `crypto/x509` / `net/url` advisories that belong to the local Go toolchain (go1.26.0, fixed in go1.26.1) and are unrelated to this change - it adds no dependencies. CI runs go1.25 with govulncheck advisory-only.
- The other gosec rules the repo's CI already excludes (G104/G107/G117/G301/G306/G704/G706) are not file-inclusion and are not touched here.

## Reference
`~/oneleet-bump/plan/oneleet-remediation-round2-plan.md`