### PR TITLE
fix: tighten file/dir permissions and annotate HTTP calls (SAST)

### DIFF
--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -610,7 +610,7 @@ func installProjectClaude(projectDir string) bool {
 		return false
 	}
 
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
 		fmt.Fprintf(os.Stderr, "   Warning: could not create %s: %v\n", claudeDir, err)
 		return false
 	}
@@ -667,7 +667,7 @@ func hasProjectCodex(projectDir string) bool {
 }
 
 func installSkillFromEmbed(skillDir, skillPath string) error {
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := os.MkdirAll(skillDir, 0750); err != nil {
 		return fmt.Errorf("creating skill directory: %w", err)
 	}
 
@@ -1190,7 +1190,7 @@ func healthDisplay(s relay.Server) string {
 func tryDeviceAuth(baseURL string) string {
 	// Check if the server supports device auth
 	checkURL := baseURL + "/api/auth/device"
-	resp, err := http.Post(checkURL, "application/json", strings.NewReader("{}"))
+	resp, err := http.Post(checkURL, //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input "application/json", strings.NewReader("{}"))
 	if err != nil {
 		return "" // Server not reachable or doesn't support device auth
 	}
@@ -1234,7 +1234,7 @@ func tryDeviceAuth(baseURL string) string {
 		time.Sleep(time.Duration(interval) * time.Second)
 
 		tokenBody, _ := json.Marshal(map[string]string{"device_code": deviceResp.DeviceCode})
-		tokenResp, err := http.Post(tokenURL, "application/json", bytes.NewReader(tokenBody))
+		tokenResp, err := http.Post(tokenURL, //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input "application/json", bytes.NewReader(tokenBody))
 		if err != nil {
 			continue
 		}

--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -1190,7 +1190,7 @@ func healthDisplay(s relay.Server) string {
 func tryDeviceAuth(baseURL string) string {
 	// Check if the server supports device auth
 	checkURL := baseURL + "/api/auth/device"
-	resp, err := http.Post(checkURL, //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input "application/json", strings.NewReader("{}"))
+	 resp, err := http.Post(checkURL, "application/json", strings.NewReader("{}")) //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input
 	if err != nil {
 		return "" // Server not reachable or doesn't support device auth
 	}
@@ -1234,7 +1234,7 @@ func tryDeviceAuth(baseURL string) string {
 		time.Sleep(time.Duration(interval) * time.Second)
 
 		tokenBody, _ := json.Marshal(map[string]string{"device_code": deviceResp.DeviceCode})
-		tokenResp, err := http.Post(tokenURL, //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input "application/json", bytes.NewReader(tokenBody))
+		tokenResp, err := http.Post(tokenURL, "application/json", bytes.NewReader(tokenBody)) //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input
 		if err != nil {
 			continue
 		}

--- a/cmd/arc-sync/main.go
+++ b/cmd/arc-sync/main.go
@@ -1190,7 +1190,7 @@ func healthDisplay(s relay.Server) string {
 func tryDeviceAuth(baseURL string) string {
 	// Check if the server supports device auth
 	checkURL := baseURL + "/api/auth/device"
-	 resp, err := http.Post(checkURL, "application/json", strings.NewReader("{}")) //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input
+	resp, err := http.Post(checkURL, "application/json", strings.NewReader("{}")) //nolint:gosec // #nosec G107 -- baseURL is operator-configured server URL, not user input
 	if err != nil {
 		return "" // Server not reachable or doesn't support device auth
 	}

--- a/internal/cli/project/codex.go
+++ b/internal/cli/project/codex.go
@@ -164,7 +164,7 @@ func loadCodexConfig(projectDir string) (map[string]any, error) {
 // existing, in-base parent to resolve against.
 func writeCodexConfig(projectDir string, raw map[string]any) error {
 	path := filepath.Join(projectDir, codexConfigFile)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
 	}
 

--- a/internal/cli/testutil/golden.go
+++ b/internal/cli/testutil/golden.go
@@ -16,11 +16,11 @@ func GoldenFile(t *testing.T, name string, got []byte) {
 	golden := filepath.Join("testdata", "golden", name)
 
 	if *update {
-		err := os.MkdirAll(filepath.Dir(golden), 0755)
+		err := os.MkdirAll(filepath.Dir(golden), 0750)
 		if err != nil {
 			t.Fatalf("failed to create golden dir: %v", err)
 		}
-		err = os.WriteFile(golden, got, 0644)
+		err = os.WriteFile(golden, got, 0600)
 		if err != nil {
 			t.Fatalf("failed to write golden file: %v", err)
 		}

--- a/internal/cli/testutil/temp_project.go
+++ b/internal/cli/testutil/temp_project.go
@@ -49,11 +49,11 @@ func TempConfigDir(t *testing.T) string {
 // parent directories as needed.
 func WriteFile(t *testing.T, path, content string) {
 	t.Helper()
-	err := os.MkdirAll(filepath.Dir(path), 0755)
+	err := os.MkdirAll(filepath.Dir(path), 0750)
 	if err != nil {
 		t.Fatalf("failed to create parent dirs for %s: %v", path, err)
 	}
-	err = os.WriteFile(path, []byte(content), 0644)
+	err = os.WriteFile(path, []byte(content), 0600)
 	if err != nil {
 		t.Fatalf("failed to write %s: %v", path, err)
 	}


### PR DESCRIPTION
> 🤖 This PR was generated by Claude Code.

## Summary
Resolves 12 of 14 Oneleet SAST alerting findings in \`comma-compliance/arc-relay\`.

## Changes

### File/directory permission fixes (10 findings)
Tightened permissions to satisfy SAST rules:
- \`Expect directory permissions to be 0750 or less\` — changed \`0755\` → \`0750\` on all \`os.MkdirAll\`/\`os.Mkdir\` calls
- \`Expect WriteFile permissions to be 0600 or less\` — changed \`0644\` → \`0600\` on all \`os.WriteFile\` calls

Files changed:
- \`internal/cli/testutil/golden.go\` — test helper creating golden file dirs/files
- \`internal/cli/testutil/temp_project.go\` — test helper creating temp project dirs/files
- \`internal/cli/project/codex.go\` — creates \`.codex/\` config dir within project
- \`cmd/arc-sync/main.go\` — creates \`.claude/\` and \`skills/\` dirs

All permission changes are safe: test helpers only need access by the test process; the \`.claude/\`/\`.codex/\`/\`skills/\` config dirs don't require world-execute.

### HTTP variable URL annotations (2 findings)
Added \`// #nosec G107\` + \`//nolint:gosec\` on the two \`http.Post\` calls in \`tryDeviceAuth\`:
- \`checkURL\` and \`tokenURL\` are both derived from \`baseURL\`, which is an operator-configured server URL — not user input. This is the intended behaviour (connecting to the configured arc-relay server).

### Remaining 2 findings (not fixed here)
\`main.go:392\` and \`main.go:644\` (file inclusion) already have \`// #nosec G304\` annotations. If Oneleet continues to flag them, they should be marked **Risk Accepted** in the Oneleet UI.

## Test plan
- [ ] CI passes (Go tests, linter)
- [ ] Oneleet SAST findings clear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)