### PR TITLE
fix: tighten temp_project.go file/dir permissions to 0600/0750

### DIFF
--- a/internal/cli/testutil/temp_project.go
+++ b/internal/cli/testutil/temp_project.go
@@ -12,7 +12,7 @@ func TempProject(t *testing.T, mcpJSON string) string {
 	t.Helper()
 	dir := t.TempDir()
 	if mcpJSON != "" {
-		err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcpJSON), 0644)
+		err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcpJSON), 0600)
 		if err != nil {
 			t.Fatalf("failed to write .mcp.json: %v", err)
 		}
@@ -25,12 +25,12 @@ func TempProject(t *testing.T, mcpJSON string) string {
 func TempProjectWithGit(t *testing.T, mcpJSON, gitignore string) string {
 	t.Helper()
 	dir := TempProject(t, mcpJSON)
-	err := os.Mkdir(filepath.Join(dir, ".git"), 0755)
+	err := os.Mkdir(filepath.Join(dir, ".git"), 0750)
 	if err != nil {
 		t.Fatalf("failed to create .git dir: %v", err)
 	}
 	if gitignore != "" {
-		err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(gitignore), 0644)
+		err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(gitignore), 0600)
 		if err != nil {
 			t.Fatalf("failed to write .gitignore: %v", err)
 		}


### PR DESCRIPTION
> 🤖 This PR was generated by Claude Code.

## Summary
- Fixes 3 remaining Oneleet SAST findings in `internal/cli/testutil/temp_project.go`
- Line 15: `os.WriteFile(..., 0644)` → `0600`
- Line 28: `os.Mkdir(..., 0755)` → `0750`
- Line 33: `os.WriteFile(..., 0644)` → `0600`
- These were missed by PR #21 which fixed other files but not these specific lines

## Test plan
- [ ] Oneleet rescans after merge and clears the 3 remaining alerting findings in `temp_project.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)